### PR TITLE
Replace Twitter-link in header with Discord-link

### DIFF
--- a/css/layout.styl
+++ b/css/layout.styl
@@ -27,12 +27,17 @@ header {
     position: absolute
     top: 60px
 
-    &.twitter {
+    &.discord {
       right: 70px
     }
 
     &.youtube {
       right: 30px
+    }
+
+    img {
+      width: 33px;
+      height: 33px;
     }
   }
 

--- a/html/header.ect
+++ b/html/header.ect
@@ -11,7 +11,7 @@
       <%- @t.langselect %> <img src="/images/flag_<%= @t.otherlang %>.png" alt="">
     </a>
 
-    <a class="icon twitter" href="https://twitter.com/clonkspot"><img src="/images/twitter.png" alt="Twitter"></a>
+    <a class="icon discord" href="https://discord.gg/rXS9F84sTM"><img src="/images/discord.png" alt="Discord"></a>
     <a class="icon youtube" href="https://youtube.com/user/clonkspot"><img src="/images/youtube.png" alt="YouTube"></a>
   </div>
 


### PR DESCRIPTION
These PR changes the Twitter-icon in the header to a Discord-icon (fixes #32). The link to Twitter is also replaced with an individual link to the Clonkspot Games server generated for this purpose only and without expiration.

Unfortunately the folder `images/` is not in the repository, so I upload the icon I created for Discord here in this PR: [discord.png.zip](https://github.com/clonkspot/frontend/files/9176725/discord.zip)
The icon is larger but has almost the same data size as the Youtube icon. This ensures future viability. The YouTube icon is barely visible with its 33px. The icon size is set by the CSS.
